### PR TITLE
Added wake pins for ESP32-C3

### DIFF
--- a/components/deep_sleep.rst
+++ b/components/deep_sleep.rst
@@ -18,7 +18,8 @@ Next, tell the node how it should wakeup. On the ESP8266, you can only put the n
 for a duration using ``sleep_duration``, note that on the ESP8266 ``GPIO16`` must be connected to
 the ``RST`` pin so that it will wake up again. On the ESP32, you additionally have the option
 to wake up on any RTC pin (``GPIO0``, ``GPIO2``, ``GPIO4``, ``GPIO12``, ``GPIO13``, ``GPIO14``,
-``GPIO15``, ``GPIO25``, ``GPIO26``, ``GPIO27``, ``GPIO32``, ``GPIO39``).
+``GPIO15``, ``GPIO25``, ``GPIO26``, ``GPIO27``, ``GPIO32``, ``GPIO39``). On the ESP32-C3, the wake 
+capable RTC pins are (``GPIO0``, ``GPIO1``, ``GPIO2``, ``GPIO3``, ``GPIO4``, ``GPIO5``).
 
 While in deep sleep mode, the node will not do any work and not respond to any network traffic,
 even Over The Air updates.


### PR DESCRIPTION
## Description:
Added RTC pins capable of waking the ESP32-C3 as listed in the technical reference manual.

**Related issue (if applicable):** fixes [https://github.com/esphome/issues/issues/2298](url)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome##3066

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
